### PR TITLE
Fix your ssh key loading

### DIFF
--- a/.zsh/robs/ssh_load_keys.zsh
+++ b/.zsh/robs/ssh_load_keys.zsh
@@ -1,8 +1,12 @@
 # load ssh keys
-ssh-add -l|grep 'no identities' > /dev/null 2>&1
 
-if [[ $? = 0 ]]; then
-  for id in `find $HOME/.ssh/ -name "id_rsa*" | grep -v 'id_rsa.pub'`; ssh-add $id
+if ssh-add -l|grep 'no identities' > /dev/null 2>&1
+then
+  for id in `find $HOME/.ssh/ -name "id_rsa*" -and -not -name "*.pub"`
+  do
+    ssh-add $id
+  done
+
   ssh-add -l
 fi
 


### PR DESCRIPTION
The `if` command takes the status code of the command that it executes as the true or false value. So you don't need to test the status code of the previous command - just make that the command if runs.

The find command supports full boolean set logic including negation so there is no need to chain a grep off that. Also chaining for and the associated command on one line doesn't read well.
